### PR TITLE
Use bash shebang

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 trap ctrl_c INT
 


### PR DESCRIPTION
Currently, the shebang in script.sh is #!/bin/sh, but the script itself uses bashisms. This causes problems when bash is not the system shell. This PR is made to explicitly use bash via the #!/bin/bash shebang. This explicitly requires bash, and it should be made a listed dependency in the AUR package.