### PR TITLE
Fixed playback bar

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 spins=0
-play audio.opus repeat 9999 </dev/null &>/dev/null &
+play -q audio.opus repeat 9999 </dev/null &>/dev/null &
 clear
 while true
 do


### PR DESCRIPTION
Using the `-q` option for `play` makes the playback bar not show up.