### PR TITLE
Fix readme using link as image instead of link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ You may wish to copy to somewhere in PATH - `/usr/bin` for example.
 
 A package is also available on the [AUR](https://aur.archlinux.org/packages/horizontallyspinningrat)
 
-A massive thanks to dylanaraps and his ![excellent guide](https://github.com/dylanaraps/writing-a-tui-in-bash) on implementing TUI features within Bash.
+A massive thanks to dylanaraps and his [excellent guide](https://github.com/dylanaraps/writing-a-tui-in-bash) on implementing TUI features within Bash.


### PR DESCRIPTION
The current README uses an image link where it should use a hyperlink. This probably messes with screen readers and leaves an unsightly missing image icon to the left of the link. This PR changes it to a hyperlink as it should be.